### PR TITLE
ci: move Mutinynet signet tests to main-only CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -111,6 +111,34 @@ jobs:
         if: always()
         run: docker compose -f tests/docker-compose.yml down
 
+  signet-smoke-test:
+    name: Signet smoke test (main only)
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install wasm-pack
+        run: curl https://raw.githubusercontent.com/rustwasm/wasm-pack/a3a48401795cd4b3afe1d74568c93675a04f3970/installer/init.sh -sSf | sh -s -- -f
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: yarn
+          cache-dependency-path: tests/node/yarn.lock
+      - name: Install dependencies
+        working-directory: tests/node
+        run: yarn install --immutable
+      - name: Build WASM (Node target)
+        working-directory: tests/node
+        run: yarn build
+      - name: Run Mutinynet signet tests
+        working-directory: tests/node
+        run: yarn jest --testPathPattern='integration/esplora'
+
   lint:
     name: Lint (fmt + clippy)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,19 +73,24 @@ yarn lint           # runs eslint
 
 Node tests are in `tests/node/integration/`:
 - `wallet.test.ts` — Wallet creation, addresses, descriptors
-- `esplora.test.ts` — Esplora sync, full scan, transaction sending (uses **Mutinynet signet**)
+- `esplora.test.ts` — Esplora sync, full scan, transaction sending (network-agnostic)
 - `utilities.test.ts` — Amount, Script, Address utilities
 - `errors.test.ts` — Error handling and error codes
 
-**Note:** `esplora.test.ts` depends on Mutinynet signet (`https://mutinynet.com/api`) with a
-pre-funded test wallet. This test can be flaky if the faucet/signet is down.
+`esplora.test.ts` is parameterized via environment variables:
+- `NETWORK` — `signet` (default) or `regtest`
+- `ESPLORA_URL` — defaults to `https://mutinynet.com/api`
 
 ### CI
 
 GitHub Actions runs on every PR:
 - **Lint:** `cargo fmt --check` + `cargo clippy --all-features --all-targets -- -D warnings`
 - **Browser build:** Three matrix configs (all features, debug+default, debug+esplora)
-- **Node build + test:** Full wasm-pack build + Jest test suite
+- **Node build + test:** Unit tests only (Esplora tests excluded)
+- **Esplora integration tests:** Regtest environment via Docker Compose (`blockstream/esplora`)
+
+On push to main only:
+- **Signet smoke test:** Runs `esplora.test.ts` against Mutinynet signet as a live network check
 
 CI must be green before merging. Clippy treats warnings as errors (`-D warnings`).
 


### PR DESCRIPTION
## Summary

Move Mutinynet/signet integration tests to run only on pushes to main, not on every PR. PRs now rely on the deterministic regtest environment for Esplora integration testing.

## Changes

### .github/workflows/build-lint-test.yml
- Add `signet-smoke-test` job with `if: github.ref == 'refs/heads/main'`
- Runs `esplora.test.ts` with default config (Mutinynet signet) as a live network check
- No changes to existing PR jobs

### CLAUDE.md
- Updated test strategy documentation to reflect the PR vs main split

## Test strategy
| Trigger | Esplora tests | Network |
|---------|--------------|---------|
| PR | Regtest (Docker) | Local, deterministic |
| Push to main | Regtest + Signet | Local + Mutinynet |

Closes #17