### PR TITLE
chore(deps): periodic dependency audit and upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,9 +746,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1487,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1500,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.63"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1514,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1524,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1537,18 +1537,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6fc7a6f61926fa909ee570d4ca194e264545ebbbb4ffd63ac07ba921bff447"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
 dependencies = [
  "async-trait",
  "cast",
@@ -1568,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f745a117245c232859f203d6c8d52c72d4cfc42de7e668c147ca6b3e45f1157e"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1579,15 +1579,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f88e7ae201cc7c291da857532eb1c8712e89494e76ec3967b9805221388e938"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
 
 [[package]]
 name = "web-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ esplora = ["bdk_esplora", "wasm-bindgen-futures"]
 debug = ["console_error_panic_hook"]
 
 [dependencies]
-wasm-bindgen = "0.2.113"
-wasm-bindgen-futures = { version = "0.4.63", optional = true }
+wasm-bindgen = "0.2.114"
+wasm-bindgen-futures = { version = "0.4.64", optional = true }
 anyhow = { version = "1.0.102", default-features = false }
 serde = { version = "1.0.228", default-features = false, features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
-web-sys = { version = "0.3.90", default-features = false, features = [
+web-sys = { version = "0.3.91", default-features = false, features = [
     "Window",
 ] }
 
@@ -44,7 +44,7 @@ bitcoin = { version = "0.32.8", default-features = false, features = [
 console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.63"
+wasm-bindgen-test = "0.3.64"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.


### PR DESCRIPTION
## Summary

Periodic dependency audit per #24. Upgrades all dependencies to their latest compatible versions.

### Changes

| Crate | From | To |
|-------|------|-----|
| wasm-bindgen | 0.2.113 | 0.2.114 |
| wasm-bindgen-futures | 0.4.63 | 0.4.64 |
| wasm-bindgen-test | 0.3.63 | 0.3.64 |
| web-sys | 0.3.90 | 0.3.91 |

### Already at latest

- `bdk_wallet` 2.3.0 ✅
- `bdk_esplora` 0.22.1 ✅
- `bitcoin` 0.32.8 ✅
- `serde` 1.0.228 ✅
- `anyhow` 1.0.102 ✅
- `serde-wasm-bindgen` 0.6.5 ✅
- `getrandom` 0.2.17 (latest 0.2.x; 0.3+ is a breaking change) ✅
- `console_error_panic_hook` 0.1.7 ✅

### Note

Cargo.lock will be auto-resolved by CI since we don't use `--locked`. Run `cargo update -p wasm-bindgen -p web-sys -p wasm-bindgen-test` locally before merging to commit a clean lock file.

Ref #24