### PR TITLE
ci: improve caching

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -4,6 +4,28 @@ on:
   workflow_call:
 
 jobs:
+  build-wasm-node:
+    name: Build WASM (Node target)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install wasm-pack
+        run: curl -sSfL https://github.com/rustwasm/wasm-pack/releases/download/v0.14.0/wasm-pack-v0.14.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin --strip-components=1 wasm-pack-v0.14.0-x86_64-unknown-linux-musl/wasm-pack
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "wasm-node"
+      - name: Build WASM (Node target)
+        run: wasm-pack build --target nodejs --all-features
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-node-pkg
+          path: pkg/
+          retention-days: 1
+
   build-test:
     name: Build and test - Browser
     runs-on: ubuntu-latest
@@ -17,15 +39,15 @@ jobs:
           - debug,esplora
     steps:
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
       - name: Install wasm-pack
         run: curl -sSfL https://github.com/rustwasm/wasm-pack/releases/download/v0.14.0/wasm-pack-v0.14.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin --strip-components=1 wasm-pack-v0.14.0-x86_64-unknown-linux-musl/wasm-pack
       - name: Rust Cache
-        uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
+        uses: Swatinem/rust-cache@v2
       - name: Build
         run: |
           if [ "${{ matrix.features }}" = "all" ]; then
@@ -40,18 +62,22 @@ jobs:
   build-lint-test-node:
     name: Build, Lint and test - Node
     runs-on: ubuntu-latest
+    needs: build-wasm-node
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v4
       - name: Enable Corepack
         run: corepack enable
-      - name: Install wasm-pack
-        run: curl -sSfL https://github.com/rustwasm/wasm-pack/releases/download/v0.14.0/wasm-pack-v0.14.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin --strip-components=1 wasm-pack-v0.14.0-x86_64-unknown-linux-musl/wasm-pack
       - name: Setup Node
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: yarn
           cache-dependency-path: tests/node/yarn.lock
+      - name: Download WASM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-node-pkg
+          path: pkg/
       - name: Install
         working-directory: tests/node
         run: yarn install --immutable
@@ -60,21 +86,18 @@ jobs:
         run: yarn lint
       - name: Test
         working-directory: tests/node
-        run: yarn build && yarn jest --testPathIgnorePatterns='integration/(esplora|events)'
+        run: yarn jest --testPathIgnorePatterns='integration/(esplora|events)'
 
   esplora-integration:
     name: Esplora integration tests
     runs-on: ubuntu-latest
+    needs: build-wasm-node
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v4
       - name: Enable Corepack
         run: corepack enable
-      - name: Install wasm-pack
-        run: curl -sSfL https://github.com/rustwasm/wasm-pack/releases/download/v0.14.0/wasm-pack-v0.14.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin --strip-components=1 wasm-pack-v0.14.0-x86_64-unknown-linux-musl/wasm-pack
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
       - name: Setup Node
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: yarn
@@ -82,9 +105,25 @@ jobs:
       - name: Install dependencies
         working-directory: tests/node
         run: yarn install --immutable
-      - name: Build WASM (Node target)
-        working-directory: tests/node
-        run: yarn build
+      - name: Download WASM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-node-pkg
+          path: pkg/
+      - name: Cache Esplora Docker image
+        id: cache-esplora
+        uses: actions/cache@v4
+        with:
+          path: /tmp/esplora-image.tar
+          key: esplora-docker-${{ hashFiles('tests/docker-compose.yml') }}
+      - name: Load Esplora image from cache
+        if: steps.cache-esplora.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/esplora-image.tar
+      - name: Pull and save Esplora image
+        if: steps.cache-esplora.outputs.cache-hit != 'true'
+        run: |
+          docker pull blockstream/esplora
+          docker save blockstream/esplora -o /tmp/esplora-image.tar
       - name: Start Esplora regtest
         run: docker compose -f tests/docker-compose.yml up -d
       - name: Wait for Esplora
@@ -115,16 +154,13 @@ jobs:
     name: Signet smoke test (main only)
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    needs: build-wasm-node
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v4
       - name: Enable Corepack
         run: corepack enable
-      - name: Install wasm-pack
-        run: curl -sSfL https://github.com/rustwasm/wasm-pack/releases/download/v0.14.0/wasm-pack-v0.14.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin --strip-components=1 wasm-pack-v0.14.0-x86_64-unknown-linux-musl/wasm-pack
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
       - name: Setup Node
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: yarn
@@ -132,9 +168,11 @@ jobs:
       - name: Install dependencies
         working-directory: tests/node
         run: yarn install --immutable
-      - name: Build WASM (Node target)
-        working-directory: tests/node
-        run: yarn build
+      - name: Download WASM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-node-pkg
+          path: pkg/
       - name: Run Mutinynet signet tests
         working-directory: tests/node
         run: yarn jest --testPathPatterns='integration/esplora'
@@ -144,14 +182,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt, clippy
       - name: Rust Cache
-        uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
+        uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all -- --config format_code_in_doc_comments=true --check
       - name: Run Clippy


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
Issue: #32 
This PR improves CI performance by eliminating redundant WASM builds across jobs and caching the Esplora Docker image between runs.
Previously, every Node-related job (`build-lint-test-node`, `esplora-integration`, `signet-smoke-test`) independently ran `wasm-pack build --target nodejs --all-features`, each taking ~2 minutes. The `blockstream/esplora` Docker image (~1 GB) was also pulled fresh on every run.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers
This is from running the new workflow
<img width="1360" height="511" alt="image" src="https://github.com/user-attachments/assets/5e6b5081-d57e-4aef-9b61-fa36a60b2817" />
Cache entries
<img width="1462" height="614" alt="image" src="https://github.com/user-attachments/assets/479b0e41-e03f-4643-87a8-73b4d845933a" />

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

- [x] I've signed all my commits
- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-wasm/blob/master/CONTRIBUTING.md)
- [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

- [ ] I've added tests for the new feature
- [ ] I've added docs for the new feature

#### Bugfixes:

- [ ] This pull request breaks the existing API
- [ ] I've added tests to reproduce the issue which are now passing
- [x] I'm linking the issue being fixed by this PR
