### PR TITLE
refactor(types): prototype inner-wrapper macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Expand Node and regtest integration coverage for wallet address lifecycle, output introspection, and fee calculation APIs ([#22](https://github.com/bitcoindevkit/bdk-wasm/issues/22))
 - Audit and refresh Rust and Node development dependencies to their latest compatible releases ([#24](https://github.com/bitcoindevkit/bdk-wasm/issues/24))
+- Prototype a declarative macro for tuple-wrapper `Deref`/`From` boilerplate while keeping `wasm_bindgen` getters explicit ([#25](https://github.com/bitcoindevkit/bdk-wasm/issues/25))
 
 ### Dependencies
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+mod macros;
+
 pub mod bitcoin;
 pub mod types;
 mod utils;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,27 @@
+macro_rules! impl_inner_wrapper {
+    ($name:ident, $inner:ty) => {
+        impl ::std::ops::Deref for $name {
+            type Target = $inner;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl From<$inner> for $name {
+            fn from(inner: $inner) -> Self {
+                Self(inner)
+            }
+        }
+    };
+
+    ($name:ident, $inner:ty, into_inner) => {
+        impl_inner_wrapper!($name, $inner);
+
+        impl From<$name> for $inner {
+            fn from(value: $name) -> Self {
+                value.0
+            }
+        }
+    };
+}

--- a/src/types/amount.rs
+++ b/src/types/amount.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use bdk_wallet::{
     bitcoin::{Amount as BdkAmount, Denomination as BdkDenomination},
     IsDust,
@@ -17,6 +15,8 @@ use crate::types::{BdkError, BdkErrorCode, ScriptBuf};
 #[wasm_bindgen]
 #[derive(Clone, Copy, Serialize)]
 pub struct Amount(BdkAmount);
+
+impl_inner_wrapper!(Amount, BdkAmount, into_inner);
 
 #[wasm_bindgen]
 impl Amount {
@@ -52,26 +52,6 @@ impl Amount {
     /// for a given script
     pub fn is_dust(&self, script: ScriptBuf) -> bool {
         self.0.is_dust(&script)
-    }
-}
-
-impl Deref for Amount {
-    type Target = BdkAmount;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<BdkAmount> for Amount {
-    fn from(inner: BdkAmount) -> Self {
-        Amount(inner)
-    }
-}
-
-impl From<Amount> for BdkAmount {
-    fn from(amount: Amount) -> Self {
-        amount.0
     }
 }
 

--- a/src/types/balance.rs
+++ b/src/types/balance.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use bdk_wallet::Balance as BdkBalance;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -9,6 +7,8 @@ use super::Amount;
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct Balance(BdkBalance);
+
+impl_inner_wrapper!(Balance, BdkBalance);
 
 #[wasm_bindgen]
 impl Balance {
@@ -49,19 +49,5 @@ impl Balance {
     #[wasm_bindgen(getter)]
     pub fn total(&self) -> Amount {
         self.0.total().into()
-    }
-}
-
-impl Deref for Balance {
-    type Target = BdkBalance;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<BdkBalance> for Balance {
-    fn from(inner: BdkBalance) -> Self {
-        Balance(inner)
     }
 }

--- a/src/types/chain.rs
+++ b/src/types/chain.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use bdk_wallet::{
     chain::{
         spk_client::{
@@ -21,25 +19,7 @@ use super::{ConfirmationBlockTime, Txid};
 #[wasm_bindgen]
 pub struct SyncRequest(BdkSyncRequest<(KeychainKind, u32)>);
 
-impl Deref for SyncRequest {
-    type Target = BdkSyncRequest<(KeychainKind, u32)>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<BdkSyncRequest<(KeychainKind, u32)>> for SyncRequest {
-    fn from(inner: BdkSyncRequest<(KeychainKind, u32)>) -> Self {
-        SyncRequest(inner)
-    }
-}
-
-impl From<SyncRequest> for BdkSyncRequest<(KeychainKind, u32)> {
-    fn from(request: SyncRequest) -> Self {
-        request.0
-    }
-}
+impl_inner_wrapper!(SyncRequest, BdkSyncRequest<(KeychainKind, u32)>, into_inner);
 
 /// Data required to perform a spk-based blockchain client full scan.
 ///
@@ -50,50 +30,14 @@ impl From<SyncRequest> for BdkSyncRequest<(KeychainKind, u32)> {
 #[wasm_bindgen]
 pub struct FullScanRequest(BdkFullScanRequest<KeychainKind>);
 
-impl Deref for FullScanRequest {
-    type Target = BdkFullScanRequest<KeychainKind>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<BdkFullScanRequest<KeychainKind>> for FullScanRequest {
-    fn from(inner: BdkFullScanRequest<KeychainKind>) -> Self {
-        FullScanRequest(inner)
-    }
-}
-
-impl From<FullScanRequest> for BdkFullScanRequest<KeychainKind> {
-    fn from(request: FullScanRequest) -> Self {
-        request.0
-    }
-}
+impl_inner_wrapper!(FullScanRequest, BdkFullScanRequest<KeychainKind>, into_inner);
 
 /// An update to [`Wallet`].
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct Update(BdkUpdate);
 
-impl Deref for Update {
-    type Target = BdkUpdate;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<BdkUpdate> for Update {
-    fn from(inner: BdkUpdate) -> Self {
-        Update(inner)
-    }
-}
-
-impl From<Update> for BdkUpdate {
-    fn from(update: Update) -> Self {
-        update.0
-    }
-}
+impl_inner_wrapper!(Update, BdkUpdate, into_inner);
 
 impl From<BdkFullScanResponse<KeychainKind>> for Update {
     fn from(result: BdkFullScanResponse<KeychainKind>) -> Self {
@@ -111,13 +55,7 @@ impl From<BdkSyncResponse> for Update {
 #[wasm_bindgen]
 pub struct ChainPosition(BdkChainPosition<BdkConfirmationBlockTime>);
 
-impl Deref for ChainPosition {
-    type Target = BdkChainPosition<BdkConfirmationBlockTime>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+impl_inner_wrapper!(ChainPosition, BdkChainPosition<BdkConfirmationBlockTime>, into_inner);
 
 #[wasm_bindgen]
 impl ChainPosition {
@@ -187,17 +125,5 @@ impl ChainPosition {
             } => transitively.map(Into::into),
             _ => None,
         }
-    }
-}
-
-impl From<BdkChainPosition<BdkConfirmationBlockTime>> for ChainPosition {
-    fn from(inner: BdkChainPosition<BdkConfirmationBlockTime>) -> Self {
-        ChainPosition(inner)
-    }
-}
-
-impl From<ChainPosition> for BdkChainPosition<BdkConfirmationBlockTime> {
-    fn from(chain_position: ChainPosition) -> Self {
-        chain_position.0
     }
 }

--- a/src/types/changeset.rs
+++ b/src/types/changeset.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use bdk_wallet::{
     chain::Merge,
     serde_json::{from_str, to_string},
@@ -13,6 +11,8 @@ use crate::result::JsResult;
 #[wasm_bindgen]
 #[derive(PartialEq)]
 pub struct ChangeSet(BdkChangeSet);
+
+impl_inner_wrapper!(ChangeSet, BdkChangeSet, into_inner);
 
 #[wasm_bindgen]
 impl ChangeSet {
@@ -33,25 +33,5 @@ impl ChangeSet {
     /// Create a new `ChangeSet` from a JSON string.
     pub fn from_json(val: &str) -> JsResult<ChangeSet> {
         Ok(ChangeSet(from_str(val)?))
-    }
-}
-
-impl Deref for ChangeSet {
-    type Target = BdkChangeSet;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<BdkChangeSet> for ChangeSet {
-    fn from(inner: BdkChangeSet) -> Self {
-        ChangeSet(inner)
-    }
-}
-
-impl From<ChangeSet> for BdkChangeSet {
-    fn from(changeset: ChangeSet) -> Self {
-        changeset.0
     }
 }

--- a/src/types/checkpoint.rs
+++ b/src/types/checkpoint.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use bdk_wallet::chain::CheckPoint as BdkCheckPoint;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -12,6 +10,8 @@ use super::BlockId;
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct CheckPoint(BdkCheckPoint);
+
+impl_inner_wrapper!(CheckPoint, BdkCheckPoint);
 
 #[wasm_bindgen]
 impl CheckPoint {
@@ -44,19 +44,5 @@ impl CheckPoint {
     /// Returns `None` if checkpoint at `height` does not exist.
     pub fn get(&self, height: u32) -> Option<Self> {
         self.0.get(height).map(Into::into)
-    }
-}
-
-impl Deref for CheckPoint {
-    type Target = BdkCheckPoint;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<BdkCheckPoint> for CheckPoint {
-    fn from(inner: BdkCheckPoint) -> Self {
-        CheckPoint(inner)
     }
 }

--- a/src/types/fee.rs
+++ b/src/types/fee.rs
@@ -1,5 +1,5 @@
 use bdk_wallet::bitcoin::FeeRate as BdkFeeRate;
-use std::{collections::HashMap, ops::Deref};
+use std::collections::HashMap;
 
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -7,13 +7,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 #[wasm_bindgen]
 pub struct FeeEstimates(HashMap<u16, f64>);
 
-impl Deref for FeeEstimates {
-    type Target = HashMap<u16, f64>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+impl_inner_wrapper!(FeeEstimates, HashMap<u16, f64>, into_inner);
 
 #[wasm_bindgen]
 impl FeeEstimates {
@@ -21,18 +15,6 @@ impl FeeEstimates {
     /// Available confirmation targets are 1-25, 144, 504 and 1008 blocks.
     pub fn get(&self, k: u16) -> Option<f64> {
         self.0.get(&k).copied()
-    }
-}
-
-impl From<HashMap<u16, f64>> for FeeEstimates {
-    fn from(inner: HashMap<u16, f64>) -> Self {
-        FeeEstimates(inner)
-    }
-}
-
-impl From<FeeEstimates> for HashMap<u16, f64> {
-    fn from(fee_estimates: FeeEstimates) -> Self {
-        fee_estimates.0
     }
 }
 
@@ -44,13 +26,7 @@ impl From<FeeEstimates> for HashMap<u16, f64> {
 #[derive(Clone, Copy)]
 pub struct FeeRate(BdkFeeRate);
 
-impl Deref for FeeRate {
-    type Target = BdkFeeRate;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+impl_inner_wrapper!(FeeRate, BdkFeeRate, into_inner);
 
 #[wasm_bindgen]
 impl FeeRate {
@@ -72,17 +48,5 @@ impl FeeRate {
     /// Converts to sat/vB rounding down.
     pub fn to_sat_per_vb_floor(&self) -> u64 {
         self.0.to_sat_per_vb_floor()
-    }
-}
-
-impl From<BdkFeeRate> for FeeRate {
-    fn from(inner: BdkFeeRate) -> Self {
-        FeeRate(inner)
-    }
-}
-
-impl From<FeeRate> for BdkFeeRate {
-    fn from(fee_rate: FeeRate) -> Self {
-        fee_rate.0
     }
 }

--- a/src/types/psbt.rs
+++ b/src/types/psbt.rs
@@ -1,5 +1,5 @@
 use bdk_wallet::serde_json::to_string;
-use std::ops::{Deref, DerefMut};
+use std::ops::DerefMut;
 use std::str::FromStr;
 
 use bdk_wallet::{
@@ -19,13 +19,7 @@ use super::{Address, Amount, FeeRate, Transaction};
 #[derive(Clone)]
 pub struct Psbt(BdkPsbt);
 
-impl Deref for Psbt {
-    type Target = BdkPsbt;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+impl_inner_wrapper!(Psbt, BdkPsbt, into_inner);
 
 impl DerefMut for Psbt {
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -119,18 +113,6 @@ impl Psbt {
     #[wasm_bindgen(js_name = clone)]
     pub fn js_clone(&self) -> Psbt {
         self.clone()
-    }
-}
-
-impl From<BdkPsbt> for Psbt {
-    fn from(inner: BdkPsbt) -> Self {
-        Psbt(inner)
-    }
-}
-
-impl From<Psbt> for BdkPsbt {
-    fn from(psbt: Psbt) -> Self {
-        psbt.0
     }
 }
 

--- a/src/types/script.rs
+++ b/src/types/script.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use bdk_wallet::bitcoin::ScriptBuf as BdkScriptBuf;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -16,13 +14,7 @@ use crate::{
 #[derive(Clone)]
 pub struct ScriptBuf(BdkScriptBuf);
 
-impl Deref for ScriptBuf {
-    type Target = BdkScriptBuf;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+impl_inner_wrapper!(ScriptBuf, BdkScriptBuf, into_inner);
 
 #[wasm_bindgen]
 impl ScriptBuf {
@@ -72,17 +64,5 @@ impl ScriptBuf {
     /// broadcastable on today's Bitcoin network.
     pub fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> Amount {
         self.0.minimal_non_dust_custom(dust_relay_fee.into()).into()
-    }
-}
-
-impl From<BdkScriptBuf> for ScriptBuf {
-    fn from(inner: BdkScriptBuf) -> Self {
-        ScriptBuf(inner)
-    }
-}
-
-impl From<ScriptBuf> for BdkScriptBuf {
-    fn from(script_buf: ScriptBuf) -> Self {
-        script_buf.0
     }
 }

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, str::FromStr};
+use std::str::FromStr;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsError;
 
@@ -16,13 +16,7 @@ use super::{TxIn, TxOut};
 #[derive(Clone)]
 pub struct Transaction(BdkTransaction);
 
-impl Deref for Transaction {
-    type Target = BdkTransaction;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+impl_inner_wrapper!(Transaction, BdkTransaction, into_inner);
 
 #[wasm_bindgen]
 impl Transaction {
@@ -144,30 +138,12 @@ impl Transaction {
     }
 }
 
-impl From<BdkTransaction> for Transaction {
-    fn from(inner: BdkTransaction) -> Self {
-        Transaction(inner)
-    }
-}
-
-impl From<Transaction> for BdkTransaction {
-    fn from(tx: Transaction) -> Self {
-        tx.0
-    }
-}
-
 /// A bitcoin transaction hash/transaction ID.
 #[wasm_bindgen]
 #[derive(Clone, Copy)]
 pub struct Txid(BdkTxid);
 
-impl Deref for Txid {
-    type Target = BdkTxid;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+impl_inner_wrapper!(Txid, BdkTxid, into_inner);
 
 #[wasm_bindgen]
 impl Txid {
@@ -180,17 +156,5 @@ impl Txid {
     #[wasm_bindgen(js_name = toString)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
-    }
-}
-
-impl From<BdkTxid> for Txid {
-    fn from(inner: BdkTxid) -> Self {
-        Txid(inner)
-    }
-}
-
-impl From<Txid> for BdkTxid {
-    fn from(txid: Txid) -> Self {
-        txid.0
     }
 }


### PR DESCRIPTION
## Summary
- add a small declarative `impl_inner_wrapper!` macro for tuple wrappers that only need `Deref` plus `From` conversions
- refactor the low-risk wrapper types that matched that exact pattern
- keep `wasm_bindgen` methods and getters explicit so the generated JS and TS surface stays easy to read

## Why this slice
Issue #25 is broad, so this PR intentionally takes the smallest safe slice first. It targets the truly repetitive structural boilerplate and leaves field-forwarding methods explicit.

I did not introduce a proc macro here because that would add substantially more maintenance complexity for a small amount of repetition.

Refs #25
