### PR TITLE
ci: cache esplora docker image

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -85,6 +85,20 @@ jobs:
       - name: Build WASM (Node target)
         working-directory: tests/node
         run: yarn build
+      - name: Cache Esplora Docker image
+        id: cache-esplora-image
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: /tmp/esplora-image.tar
+          key: esplora-docker-blockstream-esplora-${{ hashFiles('tests/docker-compose.yml') }}
+      - name: Load cached Esplora Docker image
+        if: steps.cache-esplora-image.outputs.cache-hit == 'true'
+        run: docker load --input /tmp/esplora-image.tar
+      - name: Pull and save Esplora Docker image
+        if: steps.cache-esplora-image.outputs.cache-hit != 'true'
+        run: |
+          docker pull blockstream/esplora
+          docker save blockstream/esplora --output /tmp/esplora-image.tar
       - name: Start Esplora regtest
         run: docker compose -f tests/docker-compose.yml up -d
       - name: Wait for Esplora

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Cache the Esplora Docker image in CI so regtest integration runs can reuse the pulled image across workflow runs ([#32](https://github.com/bitcoindevkit/bdk-wasm/issues/32))
 - Expand Node and regtest integration coverage for wallet address lifecycle, output introspection, fee calculation, and TxBuilder coin-selection behavior ([#22](https://github.com/bitcoindevkit/bdk-wasm/issues/22))
   - Add regtest assertions for `drain_wallet` + `drain_to` producing a single drain output
   - Add regtest assertions for `exclude_unconfirmed` and `exclude_below_confirmations(1)` ignoring trusted pending coins during coin selection


### PR DESCRIPTION
## Summary

- cache the `blockstream/esplora` Docker image tarball for the regtest integration job
- load the cached image on cache hits and pull/save it only on misses
- update the unreleased changelog for the CI caching slice

## Validation

- `git diff --check`
- workflow smoke check for the added cache/load/pull/save steps

Refs #32
