### PR TITLE
chore: add clean targets for generated artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: clean
+
+clean:
+	cargo clean
+	rm -rf bin pkg tmp
+	rm -f wasm-pack.log
+	rm -rf tests/node/node_modules tests/node/pkg tests/node/dist tests/node/build tests/node/coverage tests/node/.cache
+	find . -name '*.log' -type f -delete
+	find . -name '*.test' -type f -delete
+	find . -name '*.profraw' -type f -delete

--- a/tests/node/package.json
+++ b/tests/node/package.json
@@ -3,7 +3,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "build": "wasm-pack build --target nodejs --all-features",
-    "test": "jest"
+    "test": "jest",
+    "clean": "rm -rf node_modules pkg dist build coverage .cache *.log"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary
- add a root Makefile with a clean target for Rust, wasm-pack, and node test artifacts
- add a yarn clean script for tests/node generated files

## Validation
- make clean
- git diff --check